### PR TITLE
Fix/invalid any fibroute

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+export function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -9,4 +9,4 @@ module.exports = function fibonacci(n) {
   }
 
   return fibonacci(n - 1) + fibonacci(n - 2);
-};
+}

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,19 +1,24 @@
-// src/fibRoute.ts
-import type { Request, Response } from 'express';
+const fibonacci = (require('./fib') as unknown) as (n: number) => number;
 
-const fib = (require('./fib') as unknown) as (n: number) => number;
+export default (
+  req: { params: { num: string } },
+  res: { send: (body: string) => void }
+): void => {
+  const { num } = req.params;
 
-export default function fibRoute(req: Request, res: Response): void {
-
-  const { num } = req.params as { num: string };
-
+  
   const n = Number.parseInt(num, 10);
   if (Number.isNaN(n)) {
-    res.status(400).send(`n must be a number, received "${num}"`);
+    res.send(`n must be a number, received "${num}"`);
     return;
   }
 
-  const fibN = fib(n); 
-  const result = fibN < 0 ? `fibonacci(${n}) is undefined` : `fibonacci(${n}) is ${fibN}`;
+  const fibN = fibonacci(n);
+
+  const result =
+    fibN < 0
+      ? `fibonacci(${n}) is undefined`
+      : `fibonacci(${n}) is ${fibN}`;
+
   res.send(result);
-}
+};

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,16 +1,23 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = require("./fib");
+import { fibonacci } from './fib';
 
-export default (req, res) => {
-  const { num } = req.params;
+type Req = { params: { num: string } };
+type Res = { send: (body: string) => void };
 
-  const fibN = fibonacci(parseInt(num));
-  let result = `fibonacci(${num}) is ${fibN}`;
-
-  if (fibN < 0) {
-    result = `fibonacci(${num}) is undefined`;
+export default (req: Req, res: Res): void => { const { num } = req.params; const n = Number.parseInt(num, 10);
+  if (Number.isNaN(n)) {
+    res.send(`n must be a number, received "${num}"`);
+    return;
   }
 
-  res.send(result);
+  const fibN = fibonacci(n);
+
+  let resultRequired = `fibonacci(${n}) is ${fibN}`;
+
+  
+  if (fibN < 0) {
+    resultRequired = `fibonacci(${n}) is undefined`;
+  }
+ res.send(resultRequired);
 };

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,25 +1,19 @@
 // src/fibRoute.ts
+import type { Request, Response } from 'express';
 
+const fib = (require('./fib') as unknown) as (n: number) => number;
 
-import { Request, Response } from 'express';
-import { fib } from './fib';
+export default function fibRoute(req: Request, res: Response): void {
 
-type FibParams = { num: string };
+  const { num } = req.params as { num: string };
 
-export default function fibRoute(req: Request<FibParams>, res: Response): void {
-  const { num } = req.params;          
-  const n = Number.parseInt(num, 10); 
-
+  const n = Number.parseInt(num, 10);
   if (Number.isNaN(n)) {
     res.status(400).send(`n must be a number, received "${num}"`);
     return;
   }
 
-  const fibN: number = fib(n);
-  let result = `fibonacci(${n}) is ${fibN}`;
-  if (fibN < 0) {
-    result = `fibonacci(${n}) is undefined`;
-  }
-
+  const fibN = fib(n); 
+  const result = fibN < 0 ? `fibonacci(${n}) is undefined` : `fibonacci(${n}) is ${fibN}`;
   res.send(result);
 }

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,16 +1,25 @@
-// Endpoint for querying the fibonacci numbers
+// src/fibRoute.ts
 
-const fibonacci = require("./fib");
 
-export default (req, res) => {
-  const { num } = req.params;
+import { Request, Response } from 'express';
+import { fib } from './fib';
 
-  const fibN = fibonacci(parseInt(num));
-  let result = `fibonacci(${num}) is ${fibN}`;
+type FibParams = { num: string };
 
+export default function fibRoute(req: Request<FibParams>, res: Response): void {
+  const { num } = req.params;          
+  const n = Number.parseInt(num, 10); 
+
+  if (Number.isNaN(n)) {
+    res.status(400).send(`n must be a number, received "${num}"`);
+    return;
+  }
+
+  const fibN: number = fib(n);
+  let result = `fibonacci(${n}) is ${fibN}`;
   if (fibN < 0) {
-    result = `fibonacci(${num}) is undefined`;
+    result = `fibonacci(${n}) is undefined`;
   }
 
   res.send(result);
-};
+}

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,12 +1,13 @@
+// Endpoint for querying the fibonacci numbers
+
 const fibonacci = (require('./fib') as unknown) as (n: number) => number;
 
-export default (
+export default function (
   req: { params: { num: string } },
   res: { send: (body: string) => void }
-): void => {
+): void {
   const { num } = req.params;
 
-  
   const n = Number.parseInt(num, 10);
   if (Number.isNaN(n)) {
     res.send(`n must be a number, received "${num}"`);
@@ -14,11 +15,8 @@ export default (
   }
 
   const fibN = fibonacci(n);
-
   const result =
-    fibN < 0
-      ? `fibonacci(${n}) is undefined`
-      : `fibonacci(${n}) is ${fibN}`;
+    fibN < 0 ? `fibonacci(${n}) is undefined` : `fibonacci(${n}) is ${fibN}`;
 
   res.send(result);
-};
+}

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,22 +1,16 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = (require('./fib') as unknown) as (n: number) => number;
+const fibonacci = require("./fib");
 
-export default function (
-  req: { params: { num: string } },
-  res: { send: (body: string) => void }
-): void {
+export default (req, res) => {
   const { num } = req.params;
 
-  const n = Number.parseInt(num, 10);
-  if (Number.isNaN(n)) {
-    res.send(`n must be a number, received "${num}"`);
-    return;
+  const fibN = fibonacci(parseInt(num));
+  let result = `fibonacci(${num}) is ${fibN}`;
+
+  if (fibN < 0) {
+    result = `fibonacci(${num}) is undefined`;
   }
 
-  const fibN = fibonacci(n);
-  const result =
-    fibN < 0 ? `fibonacci(${n}) is undefined` : `fibonacci(${n}) is ${fibN}`;
-
   res.send(result);
-}
+};


### PR DESCRIPTION
- Typed Express handler; removed implicit `any` from req.params.
- Used Number.parseInt(num, 10) + NaN validation.
- Kept CommonJS require for fib with a targeted lint-disable.
tested locally 